### PR TITLE
Coverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ ScoverageKeys.coverageHighlighting := false
 ScoverageKeys.coverageMinimum := 100
 ScoverageKeys.coverageFailOnMinimum := false
 lazy val coverageIsEnabled = taskKey[Unit]("tells whether sbt-coverage is enabled")
-coverageIsEnabled := { state.value.log.info(s"scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) }
+coverageIsEnabled := { state.value.log.info("scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) }
 lazy val coverageDisable = taskKey[Unit]("disables sbt-coverage plugin.")
 coverageDisable := { ScoverageSbtPlugin.enabled = false }
 (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (coverageDisable)

--- a/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
@@ -13,7 +13,7 @@ object CoveragePlugin extends AutoPlugin {
   lazy val coverageDisable = taskKey[Unit]("disables sbt-coverage plugin.")
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    coverageIsEnabled := { state.value.log.info(s"scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) },
+    coverageIsEnabled := { state.value.log.info("scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) },
     coverageDisable := { ScoverageSbtPlugin.enabled = false },
     (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (coverageDisable),
     coverageHighlighting := false,


### PR DESCRIPTION
Changes
-----------
* enable sbt-coverage plugin with default **threshold=100%** and **fail-on-error=false**

See that dependencies are linked
------------------------------------------
1. ```sbt```
1. ```inspect test```
  1. should show that __test:coverage__ is ***not*** a dependency
1. ```inspect package```
  1. should show that __*:disableCoverage__ is a dependency

Exercise
-----------
1. ```sbt coverage test```
  1. should warn on coverage
1. ```sbt coverage package```
  1. package should clean and recompile without instrumentation

Exercise with test-project
-------------------------------
* See **[test-project](https://github.com/socrata/socrata-sbt-plugins-test-project)**

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata/socrata-sbt-plugins/2)
<!-- Reviewable:end -->
