### PR TITLE
Coverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,8 @@ import ScoverageSbtPlugin.ScoverageKeys
 ScoverageKeys.coverageHighlighting := false
 ScoverageKeys.coverageMinimum := 100
 ScoverageKeys.coverageFailOnMinimum := false
-(test in Test) <<= (test in Test) dependsOn (ScoverageKeys.coverage in Test)
-lazy val disableCoverage = taskKey[Unit]("a task that disables sbt-coverage plugin.")
-disableCoverage := { scoverage.ScoverageSbtPlugin.enabled = false }
-(Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (disableCoverage)
+lazy val coverageIsEnabled = taskKey[Unit]("tells whether sbt-coverage is enabled")
+coverageIsEnabled := { state.value.log.info(s"scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) }
+lazy val coverageDisable = taskKey[Unit]("disables sbt-coverage plugin.")
+coverageDisable := { ScoverageSbtPlugin.enabled = false }
+(Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (coverageDisable)

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ ScoverageKeys.coverageHighlighting := false
 ScoverageKeys.coverageMinimum := 100
 ScoverageKeys.coverageFailOnMinimum := false
 lazy val coverageIsEnabled = taskKey[Unit]("tells whether sbt-coverage is enabled")
-coverageIsEnabled := { state.value.log.info(s"scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) }
+coverageIsEnabled := { state.value.log.info("scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) }
 lazy val coverageDisable = taskKey[Unit]("disables sbt-coverage plugin.")
 coverageDisable := { ScoverageSbtPlugin.enabled = false }
 (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (coverageDisable)

--- a/build.sbt
+++ b/build.sbt
@@ -20,11 +20,15 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 
 (scalastyleConfig in Compile) := baseDirectory.value / "src/main/resources/scalastyle-config.xml"
 (scalastyleConfig in Test) := baseDirectory.value / "src/main/resources/scalastyle-test-config.xml"
-
 lazy val testStyleTask = taskKey[Unit]("a task that wraps 'test:scalastyle' with no input parameters.")
 testStyleTask := { val _ = (scalastyle in Test).toTask("").value }
 (test in Test) <<= (test in Test) dependsOn (testStyleTask in Test)
-
 lazy val mainStyleTask = taskKey[Unit]("a task that wraps 'scalastyle' with no input parameters.")
 mainStyleTask := { val _ = (scalastyle in Compile).toTask("").value }
 (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (mainStyleTask in Compile)
+
+import ScoverageSbtPlugin.ScoverageKeys
+ScoverageKeys.coverageHighlighting := false
+ScoverageKeys.coverageMinimum := 100
+ScoverageKeys.coverageFailOnMinimum := false
+(test in Test) <<= (test in Test) dependsOn (ScoverageKeys.coverage in Test)

--- a/build.sbt
+++ b/build.sbt
@@ -32,3 +32,6 @@ ScoverageKeys.coverageHighlighting := false
 ScoverageKeys.coverageMinimum := 100
 ScoverageKeys.coverageFailOnMinimum := false
 (test in Test) <<= (test in Test) dependsOn (ScoverageKeys.coverage in Test)
+lazy val disableCoverage = taskKey[Unit]("a task that disables sbt-coverage plugin.")
+disableCoverage := { scoverage.ScoverageSbtPlugin.enabled = false }
+(Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (disableCoverage)

--- a/src/main/scala/com/socrata/sbtplugins/CoreSettingsPlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/CoreSettingsPlugin.scala
@@ -5,7 +5,7 @@ import sbt.Keys._
 
 object CoreSettingsPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
-  override def requires: Plugins = plugins.JvmPlugin && StylePlugin
+  override def requires: Plugins = plugins.JvmPlugin && StylePlugin && CoveragePlugin
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := "2.10.4",

--- a/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
@@ -9,14 +9,15 @@ object CoveragePlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
   override def requires: Plugins = plugins.JvmPlugin && ScoverageSbtPlugin
 
-  lazy val disableCoverage = taskKey[Unit]("a task that disables sbt-coverage plugin.")
+  lazy val coverageIsEnabled = taskKey[Unit]("tells whether sbt-coverage is enabled")
+  lazy val coverageDisable = taskKey[Unit]("disables sbt-coverage plugin.")
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    disableCoverage := { scoverage.ScoverageSbtPlugin.enabled = false },
-    (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (disableCoverage),
+    coverageIsEnabled := { state.value.log.info(s"scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) },
+    coverageDisable := { ScoverageSbtPlugin.enabled = false },
+    (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (coverageDisable),
     coverageHighlighting := false,
     coverageMinimum := 100,
-    coverageFailOnMinimum := false,
-    (test in Test) <<= (test in Test) dependsOn (coverage in Test)
+    coverageFailOnMinimum := false
     )
 }

--- a/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
@@ -13,7 +13,7 @@ object CoveragePlugin extends AutoPlugin {
   lazy val coverageDisable = taskKey[Unit]("disables sbt-coverage plugin.")
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    coverageIsEnabled := { state.value.log.info(s"scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) },
+    coverageIsEnabled := { state.value.log.info("scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) },
     coverageDisable := { ScoverageSbtPlugin.enabled = false },
     (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (coverageDisable),
     coverageHighlighting := false,

--- a/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
@@ -9,8 +9,11 @@ object CoveragePlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
   override def requires: Plugins = plugins.JvmPlugin && ScoverageSbtPlugin
 
-  override def projectSettings: Seq[Def.Setting[_]] =
-    ScoverageSbtPlugin.projectSettings ++ Seq(
+  lazy val disableCoverage = taskKey[Unit]("a task that disables sbt-coverage plugin.")
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    disableCoverage := { scoverage.ScoverageSbtPlugin.enabled = false },
+    (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (disableCoverage),
     coverageHighlighting := false,
     coverageMinimum := 100,
     coverageFailOnMinimum := false,

--- a/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
@@ -1,0 +1,19 @@
+package com.socrata.sbtplugins
+
+import sbt._
+import sbt.Keys._
+import scoverage.ScoverageSbtPlugin
+import scoverage.ScoverageSbtPlugin.ScoverageKeys._
+
+object CoveragePlugin extends AutoPlugin {
+  override def trigger: PluginTrigger = allRequirements
+  override def requires: Plugins = plugins.JvmPlugin && ScoverageSbtPlugin
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    ScoverageSbtPlugin.projectSettings ++ Seq(
+    coverageHighlighting := false,
+    coverageMinimum := 100,
+    coverageFailOnMinimum := false,
+    (test in Test) <<= (test in Test) dependsOn (coverage in Test)
+    )
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1-SNAPSHOT"
+version in ThisBuild := "0.0.2-SNAPSHOT"


### PR DESCRIPTION
Changes
-----------
* enable sbt-coverage plugin with default **threshold=100%** and **fail-on-error=false**

See that dependencies are linked
------------------------------------------
1. ```sbt```
1. ```inspect test```
  1. should show that __test:coverage__ is ***not*** a dependency
1. ```inspect package```
  1. should show that __*:disableCoverage__ is a dependency

Exercise
-----------
1. ```sbt coverage test```
  1. should warn on coverage
1. ```sbt coverage package```
  1. package should clean and recompile without instrumentation

Exercise with test-project
-------------------------------
* See **[test-project](https://github.com/socrata/socrata-sbt-plugins-test-project)**

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata/socrata-sbt-plugins/3)
<!-- Reviewable:end -->
