### PR TITLE
More Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Plugins included
   * wired to run on main sources before ```compile```
   * wired to run on test sources before ```test```
 
-Coming soon
------------
+Coming soon, maybe
+------------------
 * Cloudbees-Sbt (internal) **or**
 * Cloudbees-Sbt [(GitHub)](https://github.com/timperrett/sbt-cloudbees-plugin)
 * Sbt-Dependency-Graph [(GitHub)](https://github.com/jrudolph/sbt-dependency-graph)
@@ -33,3 +33,7 @@ Coming soon
 * Sbt-Mima-Plugin Migration Manager [(GitHub)](https://github.com/typesafehub/migration-manager)
 * Sbt-BuildInfo [(GitHub)](https://github.com/sbt/sbt-buildinfo)
 * ScalaTest [(ScalaTest)](http://scalatest.org/quick_start)
+* Sbt-Doctest [(GitHub)](https://github.com/tkawachi/sbt-doctest)
+* Sbt-One-Log [(Implicitly)](http://notes.implicit.ly/post/103363035569/sbt-one-log-1-0-0)
+* Sbt-Codacy-Coverage [(GitHub)](https://github.com/codacy/sbt-codacy-coverage)
+

--- a/README.md
+++ b/README.md
@@ -36,4 +36,3 @@ Coming soon, maybe
 * Sbt-Doctest [(GitHub)](https://github.com/tkawachi/sbt-doctest)
 * Sbt-One-Log [(Implicitly)](http://notes.implicit.ly/post/103363035569/sbt-one-log-1-0-0)
 * Sbt-Codacy-Coverage [(GitHub)](https://github.com/codacy/sbt-codacy-coverage)
-

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -33,7 +33,7 @@
             <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
         </parameters>
     </check>
-    <check level="error" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+    <check level="error" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="false">
         <parameters>
             <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
         </parameters>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -101,6 +101,7 @@
     </check>
     <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -23,6 +23,11 @@
             <parameter name="tabSize"><![CDATA[2]]></parameter>
         </parameters>
     </check>
+    <check level="error" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+        </parameters>
+    </check>
     <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
         <parameters>
             <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -43,6 +43,7 @@
             <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
         </parameters>
     </check>
+    <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -126,6 +126,8 @@
         </parameters>
     </check>
     <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.VarFieldChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
     <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
     <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -69,7 +69,7 @@
             <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
+    <check level="error" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
         <parameters>
             <parameter name="allowed">1</parameter>
             <parameter name="ignoreRegex">^\&quot;\&quot;$</parameter>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -6,25 +6,8 @@
             <parameter name="maxFileLength"><![CDATA[800]]></parameter>
         </parameters>
     </check>
-    <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">
-        <parameters>
-            <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
-// See the LICENCE.txt file distributed with this work for additional
-// information regarding copyright ownership.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.]]></parameter>
-        </parameters>
-    </check>
+    <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true" >
@@ -120,4 +103,12 @@
     <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <!-- see http://docs.scala-lang.org/style/declarations.html -->
+        <!-- see http://www.scala-lang.org/files/archive/spec/2.11/05-classes-and-objects.html#modifiers -->
+        <parameters>
+            <parameter name="regex">((lazy)\s+(override|private|protected|final|implicit))|((implicit)\s+(override|private|protected|final))|((final)\s+(override|private|protected))|((private|protected)\s+(override))</parameter>
+        </parameters>
+        <customMessage>Modifiers should be declared in the following order: "(override) (private|protected) (abstract|final|sealed) (implicit) (lazy)".</customMessage>
+    </check>
 </scalastyle>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -44,6 +44,7 @@
         </parameters>
     </check>
     <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -28,6 +28,11 @@
             <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
         </parameters>
     </check>
+    <check level="error" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
+        </parameters>
+    </check>
     <check level="error" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
         <parameters>
             <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -103,6 +103,7 @@
     <check level="error" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>
             <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -52,6 +52,7 @@
     <check level="error" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>
             <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -101,7 +101,8 @@
     </check>
     <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"></check>
-    <check level="error" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true"></check>
+    <!-- TODO: enable ScalaDocChecker after bug resolved https://github.com/scalastyle/scalastyle/issues/123 -->
+    <check level="error" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="false"></check>
     <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -81,6 +81,7 @@
     <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.NonASCIICharacterChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -51,6 +51,7 @@
     <check level="error" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>
             <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -53,6 +53,7 @@
     <check level="error" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>
             <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -69,6 +69,12 @@
             <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
         </parameters>
     </check>
+    <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
+        <parameters>
+            <parameter name="allowed">1</parameter>
+            <parameter name="ignoreRegex">^\&quot;\&quot;$</parameter>
+        </parameters>
+    </check>
     <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -100,6 +100,7 @@
         </parameters>
     </check>
     <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+    <check level="error" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -127,7 +127,8 @@
         </parameters>
     </check>
     <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
-    <check level="error" class="org.scalastyle.scalariform.VarFieldChecker" enabled="true"></check>
+    <!-- TODO: enable VarFieldChecker after bug resolved https://github.com/scalastyle/scalastyle/issues/132 -->
+    <check level="error" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"></check>
     <check level="error" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
     <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -103,6 +103,7 @@
     <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>
             <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -52,6 +52,7 @@
     <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>
             <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -44,6 +44,7 @@
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -43,6 +43,7 @@
             <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
         </parameters>
     </check>
+    <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -53,6 +53,7 @@
     <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>
             <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -6,25 +6,8 @@
             <parameter name="maxFileLength"><![CDATA[800]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">
-        <parameters>
-            <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
-// See the LICENCE.txt file distributed with this work for additional
-// information regarding copyright ownership.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.]]></parameter>
-        </parameters>
-    </check>
+    <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true" >
@@ -120,4 +103,12 @@
     <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <!-- see http://docs.scala-lang.org/style/declarations.html -->
+        <!-- see http://www.scala-lang.org/files/archive/spec/2.11/05-classes-and-objects.html#modifiers -->
+        <parameters>
+            <parameter name="regex">((lazy)\s+(override|private|protected|final|implicit))|((implicit)\s+(override|private|protected|final))|((final)\s+(override|private|protected))|((private|protected)\s+(override))</parameter>
+        </parameters>
+        <customMessage>Modifiers should be declared in the following order: "(override) (private|protected) (abstract|final|sealed) (implicit) (lazy)".</customMessage>
+    </check>
 </scalastyle>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -127,7 +127,8 @@
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="true"></check>
+    <!-- TODO: enable VarFieldChecker after bug resolved https://github.com/scalastyle/scalastyle/issues/132 -->
+    <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"></check>
     <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
     <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -101,6 +101,7 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -130,7 +130,7 @@
     <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
     <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
-    <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
         <!-- see http://docs.scala-lang.org/style/declarations.html -->
         <!-- see http://www.scala-lang.org/files/archive/spec/2.11/05-classes-and-objects.html#modifiers -->
         <parameters>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -100,6 +100,7 @@
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -33,7 +33,7 @@
             <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
         </parameters>
     </check>
-    <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+    <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="false">
         <parameters>
             <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
         </parameters>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -23,6 +23,11 @@
             <parameter name="tabSize"><![CDATA[2]]></parameter>
         </parameters>
     </check>
+    <check level="warning" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+        </parameters>
+    </check>
     <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
         <parameters>
             <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -81,6 +81,7 @@
     <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NonASCIICharacterChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -69,6 +69,12 @@
             <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
         </parameters>
     </check>
+    <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
+        <parameters>
+            <parameter name="allowed">1</parameter>
+            <parameter name="ignoreRegex">^\&quot;\&quot;$</parameter>
+        </parameters>
+    </check>
     <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -101,7 +101,8 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"></check>
-    <check level="warning" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="true"></check>
+    <!-- TODO: enable ScalaDocChecker after bug resolved https://github.com/scalastyle/scalastyle/issues/123 -->
+    <check level="warning" class="org.scalastyle.scalariform.ScalaDocChecker" enabled="false"></check>
     <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.SpaceAfterCommentStartChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -28,6 +28,11 @@
             <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
         </parameters>
     </check>
+    <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
+        </parameters>
+    </check>
     <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
         <parameters>
             <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -126,6 +126,8 @@
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"></check>
     <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
     <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true">

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -51,6 +51,7 @@
     <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"></check>
     <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
         <parameters>
             <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>

--- a/src/main/resources/scalastyle-unused.txt
+++ b/src/main/resources/scalastyle-unused.txt
@@ -10,4 +10,3 @@ org.scalastyle.scalariform.SpacesBeforePlusChecker
 org.scalastyle.scalariform.TokenChecker
 org.scalastyle.scalariform.UnderscoreImportChecker
 org.scalastyle.scalariform.WhileChecker
-

--- a/src/main/resources/scalastyle-unused.txt
+++ b/src/main/resources/scalastyle-unused.txt
@@ -1,0 +1,13 @@
+org.scalastyle.file.IndentationChecker
+org.scalastyle.scalariform.BlockImportChecker
+org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker
+org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker
+org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker
+org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker
+org.scalastyle.scalariform.NotImplementedErrorUsage
+org.scalastyle.scalariform.SpacesAfterPlusChecker
+org.scalastyle.scalariform.SpacesBeforePlusChecker
+org.scalastyle.scalariform.TokenChecker
+org.scalastyle.scalariform.UnderscoreImportChecker
+org.scalastyle.scalariform.WhileChecker
+

--- a/src/main/scala/com/socrata/sbtplugins/CoreSettingsPlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/CoreSettingsPlugin.scala
@@ -3,10 +3,17 @@ package com.socrata.sbtplugins
 import sbt._
 import sbt.Keys._
 
+/** Enables autoplugins, sets scala version and compiler flags for static analysis. */
 object CoreSettingsPlugin extends AutoPlugin {
+  /** When to enable this autoplugin.
+    * @return On all requirements in all scopes. */
   override def trigger: PluginTrigger = allRequirements
+  /** Depends on these autoplugins.
+    * @return Basic jvm, style, coverage. */
   override def requires: Plugins = plugins.JvmPlugin && StylePlugin && CoveragePlugin
 
+  /** Settings for the project scope.
+    * @return Settings to import in the project scope. */
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     scalaVersion := "2.10.4",
     scalacOptions ++= Seq("-Xlint", "-deprecation", "-Xfatal-warnings", "-feature")

--- a/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
@@ -14,11 +14,12 @@ object CoveragePlugin extends AutoPlugin {
     lazy val coverageDisable = taskKey[Unit]("disables sbt-coverage plugin.")
   }
 
-  import CoverageKeys._
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    coverageIsEnabled := { state.value.log.info("scoverage enabled: %s".format(ScoverageSbtPlugin.enabled)) },
-    coverageDisable := { ScoverageSbtPlugin.enabled = false },
-    (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (coverageDisable),
+    CoverageKeys.coverageIsEnabled := {
+      state.value.log.info("scoverage enabled: %s".format(ScoverageSbtPlugin.enabled))
+    },
+    CoverageKeys.coverageDisable := { ScoverageSbtPlugin.enabled = false },
+    (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn CoverageKeys.coverageDisable,
     coverageHighlighting := false,
     coverageMinimum := 100,
     coverageFailOnMinimum := false

--- a/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/CoveragePlugin.scala
@@ -5,15 +5,28 @@ import sbt.Keys._
 import scoverage.ScoverageSbtPlugin
 import scoverage.ScoverageSbtPlugin.ScoverageKeys._
 
+/** Wraps scoverage sbt plugin.
+  *
+  * Adds ```coverageIsEnabled``` and ```coverageDisable``` keys for finer control of scoverage plugin.
+  * See also [[https://github.com/scoverage/sbt-scoverage]]. */
 object CoveragePlugin extends AutoPlugin {
+  /** When to enable this autoplugin.
+    * @return On all requirements in all scopes */
   override def trigger: PluginTrigger = allRequirements
+  /** Depends on these plugins.
+    * @return Basic jvm, scoverage */
   override def requires: Plugins = plugins.JvmPlugin && ScoverageSbtPlugin
 
+  /** Exposed tasks and settings. */
   object CoverageKeys {
+    /** Tells whether scoverage is enabled. */
     lazy val coverageIsEnabled = taskKey[Unit]("tells whether sbt-coverage is enabled")
+    /** Disables scoverage. */
     lazy val coverageDisable = taskKey[Unit]("disables sbt-coverage plugin.")
   }
 
+  /** Settings for the project scope.
+    * @return Settings to import in the project scope. */
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     CoverageKeys.coverageIsEnabled := {
       state.value.log.info("scoverage enabled: %s".format(ScoverageSbtPlugin.enabled))

--- a/src/main/scala/com/socrata/sbtplugins/HelloWorldPlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/HelloWorldPlugin.scala
@@ -3,11 +3,21 @@ package com.socrata.sbtplugins
 import sbt._
 import sbt.Keys._
 
-// Copied from http://www.scala-sbt.org/0.13/docs/Plugins.html
-// To exercise this plugin, run the command "sbt hello" in the test-project directory
+/** A simple AutoPlugin for initial testing.
+  *
+  * To exercise this plugin, run the command ```sbt hello```.
+  * Copied from [[http://www.scala-sbt.org/0.13/docs/Plugins.html]]
+  */
 object HelloWorldPlugin extends AutoPlugin {
+  /** When to enable this autoplugin.
+    * @return On all requirements in all scopes. */
   override def trigger: PluginTrigger = allRequirements
+
+  /** Settings for the build scope.
+    * @return Settings to import in build scope. */
   override lazy val buildSettings = Seq(commands += helloCommand)
+
+  /** Trivial sbt command. */
   lazy val helloCommand =
     Command.command("hello") { (state: State) =>
       println("Hi!") //scalastyle:ignore

--- a/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
@@ -87,7 +87,7 @@ object StylePlugin extends AutoPlugin {
           iStream.close()
           oStream.close()
           state.log.success(successMsg.format(target))
-        case c => state.log.error("unknown connection type %s".format(c.toString))
+        case c: Any => state.log.error("unknown connection type %s".format(c.toString))
       }
     } catch {
       case e: java.io.IOException => state.log.error(e.getMessage)

--- a/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
@@ -2,11 +2,12 @@ package com.socrata.sbtplugins
 
 import java.io.{FileOutputStream, File}
 import java.net.URL
-import java.util.jar.{JarEntry, JarFile}
 
 import sbt._
 import sbt.Keys._
 import org.scalastyle.sbt.{ScalastylePlugin, Tasks => ScalastyleTasks}
+
+import scala.language.implicitConversions
 
 object StylePlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
@@ -58,7 +59,6 @@ object StylePlugin extends AutoPlugin {
   }
 
   private def getFileFromJar(state: State, url: URL, target: File): File = {
-    import scala.language.implicitConversions
     implicit def enumToIterator[A](e: java.util.Enumeration[A]): Iterator[A] = new Iterator[A] {
       def next(): A = e.nextElement
       def hasNext: Boolean = e.hasMoreElements

--- a/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
@@ -59,6 +59,8 @@ object StylePlugin extends AutoPlugin {
   }
 
   private def getFileFromJar(state: State, url: URL, target: File): File = {
+    val successMsg = "created: %s"
+
     implicit def enumToIterator[A](e: java.util.Enumeration[A]): Iterator[A] = new Iterator[A] {
       def next(): A = e.nextElement
       def hasNext: Boolean = e.hasMoreElements
@@ -73,7 +75,7 @@ object StylePlugin extends AutoPlugin {
             val iStream = jarFile.getInputStream(e)
             IO.transfer(iStream, target)
             iStream.close()
-            state.log.success("created: " + target)
+            state.log.success(successMsg.format(target))
           })
         case connection: java.net.HttpURLConnection => state.log.error("http connection type not implemented")
         case connection: sun.net.www.protocol.file.FileURLConnection =>
@@ -84,7 +86,7 @@ object StylePlugin extends AutoPlugin {
             .foreach(oStream.write)
           iStream.close()
           oStream.close()
-          state.log.success("created: " + target)
+          state.log.success(successMsg.format(target))
         case c => state.log.error("unknown connection type %s".format(c.toString))
       }
     } catch {

--- a/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
@@ -9,10 +9,22 @@ import org.scalastyle.sbt.{ScalastylePlugin, Tasks => ScalastyleTasks}
 
 import scala.language.implicitConversions
 
+/**
+ *Wraps scalastyle-sbt-plugin.
+ *
+ * Configuration files for main and test are included as resources.
+ * See also [[http://www.scalastyle.org/]]
+ */
 object StylePlugin extends AutoPlugin {
+  /** When to enable this autoplugin.
+    * @return On all requirements in all scopes. */
   override def trigger: PluginTrigger = allRequirements
+  /** Depends on these autoplugins.
+    * @return Basic jvm. */
   override def requires: Plugins = plugins.JvmPlugin
 
+  /** Settings for the project scope.
+    * @return Settings to import in the project scope. */
   override def projectSettings: Seq[Setting[_]] =
     ScalastylePlugin.projectSettings ++
     inConfig(Compile)(configSettings) ++
@@ -25,7 +37,7 @@ object StylePlugin extends AutoPlugin {
       (Keys.`package` in Compile) <<= (Keys.`package` in Compile) dependsOn (StyleKeys.styleCheck in Compile)
     )
 
-  def configSettings: Seq[Setting[_]] = Seq(
+  private def configSettings: Seq[Setting[_]] = Seq(
     StyleKeys.styleCheck := {
       val args = Seq()
       val configXml = getFileFromJar(
@@ -52,9 +64,13 @@ object StylePlugin extends AutoPlugin {
     }
   )
 
+  /** Exposed tasks and settings */
   object StyleKeys {
+    /** Check scala source files using scalastyle. */
     val styleCheck = TaskKey[Unit]("styleCheck", "Check scala source files using scalastyle")
+    /** Location of scalastyle config file. */
     val styleConfigName = SettingKey[String]("styleConfigName", "scalastyle config file")
+    /** Location of scalastyle result file. */
     val styleResultName = SettingKey[String]("styleResultName", "scalastyle result file")
   }
 

--- a/src/main/scala/com/socrata/sbtplugins/package.scala
+++ b/src/main/scala/com/socrata/sbtplugins/package.scala
@@ -1,0 +1,10 @@
+package com.socrata
+
+/**
+  * Commonly used SBT plugins composed into one dependency.
+  *
+  * ==Overview==
+  * Adds plugins and library dependencies.
+  * Wraps older plugins in the new autoplugin style.
+  */
+package object sbtplugins

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.3"
+version in ThisBuild := "0.0.4-SNAPSHOT"


### PR DESCRIPTION
Added some more style checks.
Updated code to remove build warns/errs caused by the additions.
Added documentation.

Scala Style Checkers added
-----------------------------------
ProcedureDeclarationChecker - methods that return ```Unit``` must have ```=``` between signature and block.
RegexChecker - declaration modifiers in specific order.
ClassTypeParameterChecker - generic types must be single underscore or capital letter.
DeprecatedJavaChecker - use correct deprecated annotation.
EmptyClassChecker - exclude braces for empty class/trait.
FieldNamesChecker - fields are camel cased.
ForBraceChecker - always use braces in for-comprehension, never parens with semicolons.
ImportGroupingChecker - all imports in one spot, usually near the top.
LowercasePatternMatchChecker - prohibit confusing lowercase pattern match cases.
MultipleStringLiteralsChecker - literal string that occurs more than once should be a constant.
NonASCIICharacterChecker - require only ascii characters, protects ```=>``` from unicode arrows and such.
RedundantIfChecker - replace ```if (x) false else true``` with ```!x``` and similar.
ScalaDocChecker - **disabled** due to [issue 123](https://github.com/scalastyle/scalastyle/issues/123)
SpaceAfterCommentStartChecker - consistent comment spacing.
VarFieldChecker - prohibit mutable fields.
VarLocalChecker - allow mutable locals.


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/socrata/socrata-sbt-plugins/6)
<!-- Reviewable:end -->
